### PR TITLE
[Minor Performance Improvement] - Reserve vector, to save reallocatio…

### DIFF
--- a/xdl/xdl/core/backend/mxnet/convert_utils.cc
+++ b/xdl/xdl/core/backend/mxnet/convert_utils.cc
@@ -163,6 +163,7 @@ Status MX2XDL::ConvertType(const int s, xdl::DataType* d) {
 
 Status MX2XDL::ConvertShape(const std::vector<mx_uint>& s, xdl::TensorShape* d) {
   std::vector<size_t> dims;
+  dims.reserve(s.size());
   for (auto dim: s) {
     dims.push_back(static_cast<size_t>(dim));
   }


### PR DESCRIPTION
File: [xdl/core/backend/mxnet/convert_utils.cc]
Function: [MX2XDL::ConvertShape]

Reserving vector where we already know the size to save on reallocation costs.