### PR TITLE
目前提供的镜像ubuntu-gpu-mxnet1.3、ubuntu-gpu-tf1.12，似乎有一些问题，尝试修复了一下

### DIFF
--- a/xdl/docker/Dockerfile_for_gpu
+++ b/xdl/docker/Dockerfile_for_gpu
@@ -1,0 +1,49 @@
+# Use one of the GPU based XDL images as the parent image
+FROM registry.cn-hangzhou.aliyuncs.com/xdl/xdl:ubuntu-gpu-mxnet1.3
+#FROM registry.cn-hangzhou.aliyuncs.com/xdl/xdl:ubuntu-gpu-tf1.12
+
+LABEL maintainer "icemoon1987 <panwenhai1987@163.com>"
+
+# Remove CUDA and Nvidia related packages from the parent image to avoid conflict with the host Nvidia driver's libraries and tools.
+RUN apt -y remove cuda-*
+RUN apt -y remove nvidia-*
+
+# Install CUDA computing and machine learning components. Refer to the official Nvidia Dockerfile: https://gitlab.com/nvidia/cuda/blob/ubuntu16.04/9.0/base/Dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates apt-transport-https gnupg-curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    NVIDIA_GPGKEY_SUM=d1be581509378368edeec8c1eb2958702feedf3bc3d17011adbf24efacce4ab5 && \
+    NVIDIA_GPGKEY_FPR=ae09fe4bbd223a84b2ccfce3f60f4b3d7fa2af80 && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub && \
+    apt-key adv --export --no-emit-version -a $NVIDIA_GPGKEY_FPR | tail -n +5 > cudasign.pub && \
+    echo "$NVIDIA_GPGKEY_SUM  cudasign.pub" | sha256sum -c --strict - && rm cudasign.pub && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
+    echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
+
+ENV CUDA_VERSION 9.0.176
+
+ENV CUDA_PKG_VERSION 9-0=$CUDA_VERSION-1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cuda-cudart-$CUDA_PKG_VERSION cuda-cublas-$CUDA_PKG_VERSION cuda-core-$CUDA_PKG_VERSION cuda-cufft-$CUDA_PKG_VERSION cuda-curand-$CUDA_PKG_VERSION cuda-cusolver-$CUDA_PKG_VERSION cuda-cusparse-$CUDA_PKG_VERSION cuda-libraries-$CUDA_PKG_VERSION libcudnn7=7.0.5.15-1+cuda9.0 libcudnn7-dev=7.0.5.15-1+cuda9.0 libnccl2=2.1.4-1+cuda9.0 libnccl-dev=2.1.4-1+cuda9.0 && \
+    ln -s cuda-9.0 /usr/local/cuda && \
+    rm -rf /var/lib/apt/lists/*
+
+# nvidia-docker 1.0
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
+
+RUN echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH /usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+
+# nvidia-container-runtime
+# Add these environment variables, so nvidia-docker will map the driver libraries and tools from the host to the container. 
+# Refer to: https://devblogs.nvidia.com/gpu-containers-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_REQUIRE_CUDA "cuda>=9.0"
+
+# Fix the bug of pip
+RUN sed -i 's/pip._internal/pip/g' /usr/local/bin/pip
+


### PR DESCRIPTION
#116 为了解决这个issue，做了一些尝试。

采用这个Dockerfile构建镜像，可以正常运行nvidia-smi，并可以正常进入GPU模型训练阶段。

主要修改：
1. 依赖于提供的GPU镜像；（避免重新构建所有环境）
2. 删除GPU镜像中的cuda和nvidia相关库；（解决nvidia-driver冲突）
3. 采用Nvidia官方的方式，重新安装用到的cuda计算库；（解决安装cuda大包联带安装nvidia-driver，解决cuda 9库小版本问题）
4. 补充必要的环境变量，是的nvidia-docker加载宿主机nvidia-driver相关库和工具。（解决nvidia-docker启动镜像问题）
5. 稍微修改pip脚本，使其可用。（解决pip问题）