### PR TITLE
fix bug.

### DIFF
--- a/xdl-algorithm-solution/TDM/src/tdm/bitmap.cc
+++ b/xdl-algorithm-solution/TDM/src/tdm/bitmap.cc
@@ -22,6 +22,8 @@ limitations under the License.
 #include <stdint.h>
 #include <string.h>
 
+#include <algorithm>
+
 namespace tdm {
 
 Bitmap::Bitmap(): data_(NULL), capacity_(0) {
@@ -91,9 +93,10 @@ bool Bitmap::set_filter(size_t index, bool filter) {
     if (data_ != NULL && capacity_ > 0) {
       memcpy(new_data, data_, capacity_);
     }
-    data_ = new_data;
+
+    std::swap(data_, new_data);
     capacity_ = cap;
-    free(data_);
+    free(new_data);
   }
 
   uint64_t* ptr = reinterpret_cast<uint64_t*>(data_);

--- a/xdl/ps-plus/ps-plus/common/status.h
+++ b/xdl/ps-plus/ps-plus/common/status.h
@@ -58,7 +58,7 @@ class Status {
 
   Status(const Status& s) : state_(s.state_ == nullptr ? nullptr : new State(*s.state_)) {}
   void operator=(const Status& s) {
-    if (!state_) delete state_;
+    if (state_) delete state_;
     state_ = s.state_ == nullptr ? nullptr : new State(*s.state_);
   }
 

--- a/xdl/xdl/core/lib/status.h
+++ b/xdl/xdl/core/lib/status.h
@@ -43,7 +43,7 @@ class Status {
   Status(const Status& s)
       : state_(s.state_ == nullptr ? nullptr : new State(*s.state_)) {}
   void operator=(const Status& s) {
-    if (!state_) delete state_;
+    if (state_) delete state_;
     state_ = s.state_ == nullptr ? nullptr : new State(*s.state_);
   }
 


### PR DESCRIPTION
Modify the file "xdl-algorithm-solution/TDM/src/tdm/bitmap_test.cc" as follows：
```git
--- a/xdl-algorithm-solution/TDM/src/tdm/bitmap_test.cc
+++ b/xdl-algorithm-solution/TDM/src/tdm/bitmap_test.cc
@@ -34,15 +34,15 @@ TEST(Bitmap, TestSetFilter) {
   ASSERT_TRUE(bitmap.set_filter(index, true));
   ASSERT_TRUE(bitmap.is_filtered(index));
 
-  index = 1000;
+  index = 100000;
   ASSERT_TRUE(bitmap.set_filter(index, true));
   ASSERT_TRUE(bitmap.is_filtered(index));
 
-  index = 2000;
+  index = 200000;
   ASSERT_TRUE(bitmap.set_filter(index, true));
   ASSERT_TRUE(bitmap.is_filtered(index));
 
-  index = 5000;
+  index = 500000;
   ASSERT_TRUE(bitmap.set_filter(index, true));
   ASSERT_TRUE(bitmap.is_filtered(index));
 
@@ -51,7 +51,12 @@ TEST(Bitmap, TestSetFilter) {
 
 TEST(Bitmap, TestSave) {
   Bitmap bitmap("bitmap.bm");
-  ASSERT_TRUE(bitmap.is_filtered(5000));
+  ASSERT_TRUE(bitmap.is_filtered(500000));
```
The running result is：
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from Bitmap
[ RUN      ] Bitmap.TestConstructor
[       OK ] Bitmap.TestConstructor (0 ms)
[ RUN      ] Bitmap.TestSetFilter
**Segmentation fault (core dumped)**

