### PR TITLE
Fix std::function missing

### DIFF
--- a/xdl-algorithm-solution/ESMM/data/src/blocking_queue.h
+++ b/xdl-algorithm-solution/ESMM/data/src/blocking_queue.h
@@ -39,6 +39,7 @@ limitations under the License.
 #include <unordered_map>
 #include <set>
 #include <string>
+#include <functional>
 #include <type_traits>
 
 namespace xdl {


### PR DESCRIPTION
The header file `<functional>` is not implicitly included in some (uncertain) standard library implementations.