### PR TITLE
fix CHECK bug

### DIFF
--- a/xdl/xdl/data_io/data_io.cc
+++ b/xdl/xdl/data_io/data_io.cc
@@ -401,7 +401,7 @@ bool DataIO::GetUniqueIds() const {
 }
 
 void DataIO::SetSgroupQueueCapacity(size_t capacity) {
-  CHECK(!running_);
+  XDL_CHECK(!running_);
   sgroup_queue_capacity_ = capacity;
 }
 


### PR DESCRIPTION
blaze-fix-v1.2 
```
void DataIO::SetSgroupQueueCapacity(size_t capacity) {
  CHECK(!running_);
  sgroup_queue_capacity_ = capacity;
}
```
CHECK is undefined，should use XDL_CHECK