### PR TITLE
Fix memset call in xdl/data_io/packer/pack_feature

### DIFF
--- a/xdl/xdl/data_io/packer/pack_feature.cc
+++ b/xdl/xdl/data_io/packer/pack_feature.cc
@@ -354,7 +354,7 @@ std::pair<int, int> PackFeature::Run(const PParam &pparam) {
     }
 
     std::vector<int8_t> feature_hits(tstat.seq_.size());
-    memset(&feature_hits[0], feature_hits.size(), 0);
+    memset(&feature_hits[0], 0, feature_hits.size());
 
     /// foreach feature
     for (auto &f: fl.features()) {


### PR DESCRIPTION
The `void *memset(void *s, int c, size_t n)` function takes the value to fill in its 2nd argument and the number of byte to fill in in 3rd.

This commit fixes an invalid use of `memset` which had the two arguments swapped and it did not set any memory at all in the end due to that.